### PR TITLE
Adding a feature to get system vitals

### DIFF
--- a/alexis.py
+++ b/alexis.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
                 try:
                     print("Diagnosing system to collect vital stats")
 
-                    # Get CP usage
+                    # Get CPU usage
                     print(f"The CPU usage is: {psutil.cpu_percent(4)} %") # We get the CPU usage for the past 4 seconds
 
                     # Get memory usage

--- a/alexis.py
+++ b/alexis.py
@@ -11,6 +11,8 @@ import pytube
 import requests
 # For email
 import smtplib
+# For system stats
+import psutil
 # For getting password anonymously
 import getpass
 from utils import response_consts as resconst
@@ -141,6 +143,23 @@ if __name__ == '__main__':
                 date_today = date.today()
                 date_today = date_today.strftime("%B %d, %Y")
                 print("\033[36mIt's", date_today)
+
+            # System information / vitals
+            elif "vitals" in command:
+                try:
+                    print("Diagnosing system to collect vital stats")
+
+                    # Get CP usage
+                    print(f"The CPU usage is: {psutil.cpu_percent(4)} %") # We get the CPU usage for the past 4 seconds
+
+                    # Get memory usage
+                    print(f"RAM memory used: {psutil.virtual_memory()[2]} %")
+
+                    # Get battery percentage
+                    battery_status = psutil.sensors_battery()
+                    print(f"Percentage of battery: {battery_status.percent} %")
+                except:
+                    print("An error occurred while collecting system vitals")
 
             # TicTacToe
             elif "tic tac toe" in command or "x and o" in command or "xo" in command or "x n o" in command \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy
 speechrecognition
 pytest
 pytube~=12.1.0
+psutil~=5.9.6

--- a/res/AllCommands.txt
+++ b/res/AllCommands.txt
@@ -9,6 +9,7 @@ GENERAL
     show dog/cat
     Date
     Time
+    Vitals - displays the system stats like CPU usage, RAM usage and battery percentage
     download youtube video/download video/mp4
     video stats/video info/video information/video statistics
 ------------------------------------------------------------------------------


### PR DESCRIPTION
This pull request aims to simulate a Jarvis scene from Ironman where Jarvis is able to give damage reports to Tony. On a similar track, this PR aims to give the user system vitals/stats such as:

- [x] CPU Usage percentage
- [x] RAM Usage percentage
- [x] Battery percentage

This is cross platform and should work across OS. I have personally tested it on Windows 11. The command to get the system stats should include "vitals". Some sample commands are:

```Get me the system vitals```
```Show me the system vitals```
```Give me stats on the vitals```
```Information on vitals```  

This PR is associated with the issue  #1 